### PR TITLE
Exit non-zero when cross mismatches exist (always)

### DIFF
--- a/txbatch.py
+++ b/txbatch.py
@@ -341,7 +341,8 @@ def main() -> int:
             f"{warn_icon}{mismatch_count} transaction(s) had cross-provider mismatches.",
             file=sys.stderr,
         )
-        return 2 if w3b is not None else 0
+                return 2 if w3b is not None else 1
+
 
     # Non-zero if we had serious problems
     if fail_count > 0 or not_found_count > 0 or invalid_count > 0:


### PR DESCRIPTION
Right now return 2 only if w3b is set; keep that but make it a bit clearer.