### PR TITLE
Add per-RPC metadata into each result

### DIFF
--- a/tx_batch_auditor.py
+++ b/tx_batch_auditor.py
@@ -151,6 +151,8 @@ def audit_tx(
         "errorPrimary": None,
         "errorSecondary": None,
         "timingSec": None,
+        "primaryChainId": int(w3_primary.eth.chain_id),
+        "secondaryChainId": int(w3_secondary.eth.chain_id) if w3_secondary is not None else None,
     }
 
     # Primary


### PR DESCRIPTION
Avoid having to look up primary.chainId at the top-level only